### PR TITLE
Test External Signup Slack button

### DIFF
--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -85,6 +85,23 @@ module.exports.postCampaignDetailMessage = function (channel, environmentName, c
 };
 
 /**
+ * @param {string} channelId
+ * @param {string} userId - Slack ID
+ */
+module.exports.postExternalSignupMenuMessage = function (channelId, userId, campaignId) {
+  const data = {
+    slackChannel: channelId,
+    slackId: userId,
+    campaignId,
+    template: 'externalSignupMenuMessage',
+  };
+
+  return gambitConversations.postOutboundMessage(data)
+    .then(res => logger.debug('gambitConversations.postOutboundMessage', res.body))
+    .catch(err => rtm.sendMessage(err.message, channelId));
+};
+
+/**
  * Posts given messageText to given Slack channel.
  * @param {string} channel
  * @param {string} messageText

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -147,7 +147,7 @@ rtm.on(RTM_EVENTS.MESSAGE, (message) => {
     mediaUrl,
   };
 
-  return gambitConversations.postMessage(data)
-    .then(res => logger.debug('gambitChatbot.postMessage success', res))
+  return gambitConversations.postInboundMessage(data)
+    .then(res => logger.debug('gambitConversations.postInboundMessage', res.body))
     .catch(err => rtm.sendMessage(err.message, channel));
 });

--- a/app/routes/slack.js
+++ b/app/routes/slack.js
@@ -16,12 +16,19 @@ router.post('/', (req, res) => {
   if (payload.token !== process.env.SLACK_VERFICIATION_TOKEN) {
     return res.status(403).end('Access forbidden');
   }
-
   res.status(200).end();
-  const channelId = payload.channel.id;
-  const data = slack.parseCallbackId(payload.callback_id);
 
-  return controller.postCampaignDetailMessage(channelId, data.environmentName, data.campaignId);
+  const channelId = payload.channel.id;
+  const userId = payload.user.id;
+  const data = slack.parseCallbackId(payload);
+  const campaignId = data.campaignId;
+  const action = payload.actions[0];
+
+  if (action.value === 'external-signup') {
+    return controller.postExternalSignupMenuMessage(channelId, userId, campaignId);
+  }
+
+  return controller.postCampaignDetailMessage(channelId, data.environmentName, campaignId);
 });
 
 module.exports = router;

--- a/lib/gambit/conversations.js
+++ b/lib/gambit/conversations.js
@@ -31,3 +31,13 @@ module.exports.postInboundMessage = function (data) {
 
   return post('receive-message', data);
 };
+
+/**
+ * @param {object} data
+ * @return {Promise}
+ */
+module.exports.postOutboundMessage = function (data) {
+  logger.debug('chatbot.postOutboundMessage', data);
+
+  return post('send-message', data);
+};

--- a/lib/gambit/conversations.js
+++ b/lib/gambit/conversations.js
@@ -8,23 +8,26 @@ const authName = process.env.DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME || 'pup
 const authPass = process.env.DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS || 'totallysecret';
 
 /**
+ * @param {string} endpoint
+ * @param {object} data
+ @ @return {Promise}
+ */
+function post(endpoint, data) {
+  const url = `${uri}${endpoint}`;
+  logger.debug('post', { url, data });
+
+  return superagent
+    .post(url)
+    .auth(authName, authPass)
+    .send(data);
+}
+
+/**
  * @param {object} data
  * @return {Promise}
  */
-module.exports.postMessage = function (data) {
-  logger.debug('chatbot.postMessage', data);
+module.exports.postInboundMessage = function (data) {
+  logger.debug('chatbot.postInboundMessage', data);
 
-  return new Promise((resolve, reject) => {
-    superagent
-      .post(`${uri}receive-message`)
-      .auth(authName, authPass)
-      .send(data)
-      .then((res) => {
-        const reply = res.body.reply;
-        logger.debug('chatbot.postMessage success', reply);
-
-        return resolve(reply);
-      })
-      .catch(err => reject(err));
-  });
+  return post('receive-message', data);
 };

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -22,10 +22,11 @@ function getMobileCommonsGroupsText(campaign) {
 }
 
 /**
- * @param {string} callbackId
+ * @param {object} payload
  * @return {object}
  */
-module.exports.parseCallbackId = function (callbackId) {
+module.exports.parseCallbackId = function (payload) {
+  const callbackId = payload.callback_id;
   const data = callbackId.split('_');
 
   return {
@@ -55,7 +56,13 @@ module.exports.parseCampaignAsAttachment = function (environmentName, campaign, 
         name: 'action',
         text: 'View messages',
         type: 'button',
-        value: 'messages',
+        value: 'view-messages',
+      },
+      {
+        name: 'action',
+        text: 'Test web signup',
+        type: 'button',
+        value: 'external-signup',
       },
     ],
     fields: [

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -14,9 +14,12 @@ function getCallbackIdForCampaign(environmentName, campaign) {
  */
 function getMobileCommonsGroupsText(campaign) {
   const uri = 'https://secure.mcommons.com/groups';
+  const doingUrl = `${uri}/${campaign.mobilecommons_group_doing}`;
+  const completedUrl = `${uri}/${campaign.mobilecommons_group_completed}`;
 
-  let text = `- Doing: ${uri}/${campaign.mobilecommons_group_doing}`;
-  text = `${text}\n- Completed: ${uri}/${campaign.mobilecommons_group_completed}\n`;
+  // Render links
+  // @see https://api.slack.com/docs/message-formatting#linking_to_urls
+  const text = `<${doingUrl}|Doing> | <${completedUrl}|Completed>`;
 
   return text;
 }


### PR DESCRIPTION
Adds a "Test web signup" button to our Slack app's Campaign Index, posts to Conversations `/send-message` for the selected Campaign to test https://github.com/DoSomething/gambit-conversations/issues/77.

### Testing

Will deploy each branch to staging to test with `@gambit-staging`, but here are the steps for testing locally:
* Configure your Slack environment variables for the `@gambit-dev` app
* Run this branch locally, start ngrok, and update the Interactive Message URL in the Gambit Dev Slack app
* DM the `thor` keyword to the `@gambit-dev` Bot user in Slack
* Select the "Test web signup" action for a Campaign
* Confirm the Campaign's External Signup Message is sent, and your Conversation is now set to the Campaign you selected 

### Screenshots
New Interactive Message button:

<img width="350" alt="screen shot 2017-08-21 at 3 42 56 pm" src="https://user-images.githubusercontent.com/1236811/29541358-6377e510-8688-11e7-9e2a-66f74aacab8f.png">


I've selected "Sincerely, Us", and my Conversation is set accordingly:
<img width="350" alt="screen shot 2017-08-21 at 3 44 55 pm" src="https://user-images.githubusercontent.com/1236811/29541367-6bb908f8-8688-11e7-8c15-3845c7aff206.png">

